### PR TITLE
Add Content-length to the HTTP header for the JSON to be sent

### DIFF
--- a/gsitool/Sender.cs
+++ b/gsitool/Sender.cs
@@ -48,6 +48,7 @@ namespace gsitool
                 var httpWebRequest = (HttpWebRequest)WebRequest.Create(uri);
                 httpWebRequest.ContentType = "application/json";
                 httpWebRequest.Method = "POST";
+                httpWebRequest.ContentLength = json.Length;
                 using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))
                 {
                     streamWriter.Write(json);


### PR DESCRIPTION
Added a Content-length -value to the HTTP header of the request to be sent when sending JSON data to user-defined endpoints to avoid issues with sending the request.